### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 [*]
 indent_size = 4
 
-[*.yaml]
+[*.{yaml,py,pyw,pyx,pxd,pxi,pyi}]
 indent_style = space
 
 [*.{h,cpp,c}]


### PR DESCRIPTION
Making Python source files treatment conform to PEP8 recommendation (4 spaces, no tabs).