### PR TITLE
EditorWindow: give the toolbar 'open' button a recent files dropdown

### DIFF
--- a/src/editor/EditorWindow.cpp
+++ b/src/editor/EditorWindow.cpp
@@ -160,7 +160,7 @@ EditorWindow::EditorWindow(bool stagger)
 	AddShortcut('T', B_COMMAND_KEY | B_OPTION_KEY, new BMessage((uint32) OPEN_TERMINAL));
 
 	fOpenRecentMenu = fMainMenu->FindItem(MAINMENU_OPEN_RECENT)->Menu();
-	_PopulateOpenRecentMenu();
+	_PopulateOpenRecentMenu(fOpenRecentMenu);
 
 	fLanguageMenu = fMainMenu->FindItem(MAINMENU_LANGUAGE)->Menu();
 	_PopulateLanguageMenu();
@@ -187,6 +187,11 @@ EditorWindow::EditorWindow(bool stagger)
 		B_TRANSLATE("New"), "new document");
 	fToolbar->AddAction(MAINMENU_FILE_OPEN,
 		B_TRANSLATE("Open" B_UTF8_ELLIPSIS), "open");
+	BButton* openButton = fToolbar->FindButton(MAINMENU_FILE_OPEN);
+	if(openButton != nullptr) {
+		openButton->SetBehavior(BButton::B_POP_UP_BEHAVIOR);
+		openButton->SetPopUpMessage(new BMessage(TOOLBAR_OPEN_RECENT));
+	}
 	fToolbar->AddAction(MAINMENU_FILE_RELOAD,
 		B_TRANSLATE("Reload"), "reload");
 	fToolbar->SetActionEnabled(MAINMENU_FILE_RELOAD, false);
@@ -661,6 +666,21 @@ EditorWindow::MessageReceived(BMessage* message)
 		case MAINMENU_LANGUAGE: {
 			_SetLanguage(message->GetString("lang", "text"));
 		} break;
+		case TOOLBAR_OPEN_RECENT: {
+			BButton* button = fToolbar->FindButton(MAINMENU_FILE_OPEN);
+			if(button == nullptr) {
+				return;
+			}
+			BPopUpMenu* menu = new BPopUpMenu("RecentsPopUp", false, false);
+			_PopulateOpenRecentMenu(menu);
+			menu->SetTargetForItems(this);
+			BPoint menuPoint(ConvertToScreen(fToolbar->ConvertToParent(button->Frame().LeftBottom())));
+			menuPoint.x += 2;
+			menuPoint.y += 1;
+			button->SetValue(1);
+			menu->Go(menuPoint, true);
+			button->SetValue(0);
+		} break;
 		case TOOLBAR_SPECIAL_SYMBOLS: {
 			bool pressed = fPreferences->fWhiteSpaceVisible && fPreferences->fEOLVisible;
 			if(pressed == true) {
@@ -905,24 +925,24 @@ EditorWindow::SetOnQuitReplyToMessage(BMessage* message)
 
 
 void
-EditorWindow::_PopulateOpenRecentMenu()
+EditorWindow::_PopulateOpenRecentMenu(BMenu* menu)
 {
 	BMessage refList;
 	be_roster->GetRecentDocuments(&refList, 10, nullptr, gAppMime);
 
 	message_property<B_REF_TYPE> refs(&refList, "refs");
 	if(refs.size() == 0) {
-		fOpenRecentMenu->ItemAt(0)->SetEnabled(false);
+		menu->ItemAt(0)->SetEnabled(false);
 	} else {
 		// Clear the menu first
-		int32 count = fOpenRecentMenu->CountItems();
-		fOpenRecentMenu->RemoveItems(0, count, true);
+		int32 count = menu->CountItems();
+		menu->RemoveItems(0, count, true);
 		for(auto ref : refs) {
 			BPath p(&ref);
 			BMessage *msg = new BMessage(B_REFS_RECEIVED);
 			msg->AddRef("refs", &ref);
 			BMenuItem *menuItem = new BMenuItem(p.Path(), msg);
-			fOpenRecentMenu->AddItem(menuItem);
+			menu->AddItem(menuItem);
 		}
 	}
 }

--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -83,6 +83,7 @@ enum {
 	MAINMENU_LANGUAGE					= 'ml00',
 	MAINMENU_OPEN_RECENT				= 'mr00',
 
+	TOOLBAR_OPEN_RECENT					= 'tlor',
 	TOOLBAR_SPECIAL_SYMBOLS				= 'tlss',
 
 	FILE_OPEN							= 'flop',
@@ -162,7 +163,7 @@ private:
 	static	Preferences*	fPreferences;
 			FilePreferences	fFilePreferences;
 
-			void			_PopulateOpenRecentMenu();
+			void			_PopulateOpenRecentMenu(BMenu* menu);
 			void			_PopulateLanguageMenu();
 			void			_ReloadFile(entry_ref* ref = nullptr);
 			void			_SetLanguage(std::string lang);


### PR DESCRIPTION
This is in addition to its normal button behavior.
Also, adjust _PopulateOpenRecentMenu() so that we can reuse it for this menu as well.