### PR TITLE
minor code cleanups for help output and cursor style

### DIFF
--- a/src/editor/EditorWindow.cpp
+++ b/src/editor/EditorWindow.cpp
@@ -1334,7 +1334,7 @@ EditorWindow::_SyncWithPreferences()
 		fEditor->SendMessage(SCI_SETCARETLINEVISIBLEALWAYS, true, 0);
 		fEditor->SendMessage(SCI_SETCARETLINEFRAME, fPreferences->fLineHighlightingMode ? 2 : 0);
 		fEditor->SendMessage(SCI_SETCARETSTYLE,
-			fPreferences->fUseBlockCursor ? (CARETSTYLE_BLOCK | CARETSTYLE_BLOCK_AFTER) : CARETSTYLE_LINE, 0);
+			fPreferences->fUseBlockCursor ? (CARETSTYLE_BLOCK | CARETSTYLE_BLOCK_AFTER) : CARETSTYLE_LINE);
 
 		if(fFilePreferences.fEOLMode) {
 			fEditor->SendMessage(SCI_SETEOLMODE, fFilePreferences.fEOLMode.value_or(SC_EOL_LF), 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,13 +17,13 @@
 void
 _PrintUsage(std::ostream& outStream)
 {
-	outStream
-		<< "Usage: Koder [options] file...\n"
-		<< "Options:\n"
-		<< "  -h, --help\t\tPrints this message.\n"
-		<< "  -w, --wait\t\tWait for the window to quit before returning.\n"
-		<< "\t\t\tOpening in window stacks is not supported in this mode.\n"
-		<< "\t\t\tCurrently accepts only one filename.\n";
+	outStream <<
+		"Usage: Koder [options] file...\n"
+		"Options:\n"
+		"  -h, --help\t\tPrints this message.\n"
+		"  -w, --wait\t\tWait for the window to quit before returning.\n"
+		"\t\t\tOpening in window stacks is not supported in this mode.\n"
+		"\t\t\tCurrently accepts only one filename.\n";
 }
 
 


### PR DESCRIPTION
Remove an extra arg from the SCI_SETCARETSTYLE command and some 
extra shift operators in the help output.